### PR TITLE
Moved CLEAN_OUTPUT assignment after loading configuration files. Check that it is used only with -l or -x

### DIFF
--- a/spotify_profile_monitor.py
+++ b/spotify_profile_monitor.py
@@ -5165,16 +5165,6 @@ def main():
 
     args = parser.parse_args()
 
-    if args.export_for_spotify_monitor:
-        CLEAN_OUTPUT = True
-
-    if not CLEAN_OUTPUT:
-        stdout_bck = sys.stdout
-
-        clear_screen(CLEAR_SCREEN)
-
-        print(f"Spotify Profile Monitoring Tool v{VERSION}\n")
-
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
@@ -5228,6 +5218,20 @@ def main():
             val = os.getenv(secret)
             if val is not None:
                 globals()[secret] = val
+
+    if args.export_for_spotify_monitor:
+        if not args.list_tracks_for_playlist and not args.list_liked_tracks:
+            print(f"* Error: The 'export for spotify monitor' feature is only supported with -l and -x command line options !")
+            sys.exit(2)
+        else:
+            CLEAN_OUTPUT = True
+
+    if not CLEAN_OUTPUT:
+        stdout_bck = sys.stdout
+
+        clear_screen(CLEAR_SCREEN)
+
+        print(f"Spotify Profile Monitoring Tool v{VERSION}\n")
 
     local_tz = None
     if LOCAL_TIMEZONE == "Auto":

--- a/spotify_profile_monitor.py
+++ b/spotify_profile_monitor.py
@@ -21,6 +21,30 @@ wcwidth (optional, needed by TRUNCATE_CHARS feature)
 
 VERSION = "2.7"
 
+# API 401 error means sp_dc cookie has expired. Lasts one year. 03/15/2025
+
+# spotify-friend-stalker: https://github.com/moritzlauper/spotify-friend-stalker (node.js)
+# spotify-buddylist API:  https://github.com/valeriangalliat/spotify-buddylist (node.js)
+# spotify-api:            https://developer.spotify.com/documentation/web-api (official API)
+# spotify-monitor:        https://github.com/misiektoja/spotify_monitor/
+# spotify-api-python:     https://github.com/thlucas1/SpotifyWebApiPython (reference only)
+
+# revision history
+# 2025/03/28: Finished updating with new features to export playlists into format to import directly into spotify_monitor
+# 2025/03/30: Updated to 2.0.1 from spotify_profile_monitor source
+# 2025/04/02: Spotify_list_saved_tracks and spotify_list_tracks_for_playlist have option to write to file directly
+# 2025/04/02: Spotify_list_saved_tracks and spotify_list_tracks_for_playlist will not overwrite file if there's an error fetching spotify data
+# 2025/06/12: Updated to latest source from github
+# 2025/06/14: Added feature to manually add additional playlists to monitor (not all public playlists show up automatically)
+# 2025/07/07: Added truncation feature to this script
+# 2025/07/07: Upgraded to latest source
+
+# bugs and to-dos:
+#*** PR load extra playlists
+
+# command line examples
+# *** see .conf file
+
 # ---------------------------
 # CONFIGURATION SECTION START
 # ---------------------------

--- a/spotify_profile_monitor.py
+++ b/spotify_profile_monitor.py
@@ -21,30 +21,6 @@ wcwidth (optional, needed by TRUNCATE_CHARS feature)
 
 VERSION = "2.7"
 
-# API 401 error means sp_dc cookie has expired. Lasts one year. 03/15/2025
-
-# spotify-friend-stalker: https://github.com/moritzlauper/spotify-friend-stalker (node.js)
-# spotify-buddylist API:  https://github.com/valeriangalliat/spotify-buddylist (node.js)
-# spotify-api:            https://developer.spotify.com/documentation/web-api (official API)
-# spotify-monitor:        https://github.com/misiektoja/spotify_monitor/
-# spotify-api-python:     https://github.com/thlucas1/SpotifyWebApiPython (reference only)
-
-# revision history
-# 2025/03/28: Finished updating with new features to export playlists into format to import directly into spotify_monitor
-# 2025/03/30: Updated to 2.0.1 from spotify_profile_monitor source
-# 2025/04/02: Spotify_list_saved_tracks and spotify_list_tracks_for_playlist have option to write to file directly
-# 2025/04/02: Spotify_list_saved_tracks and spotify_list_tracks_for_playlist will not overwrite file if there's an error fetching spotify data
-# 2025/06/12: Updated to latest source from github
-# 2025/06/14: Added feature to manually add additional playlists to monitor (not all public playlists show up automatically)
-# 2025/07/07: Added truncation feature to this script
-# 2025/07/07: Upgraded to latest source
-
-# bugs and to-dos:
-#*** PR load extra playlists
-
-# command line examples
-# *** see .conf file
-
 # ---------------------------
 # CONFIGURATION SECTION START
 # ---------------------------


### PR DESCRIPTION
The CLEAN_OUTPUT feature was intended for -l and -x usage, but the code was not checking for that. Fixed this.

The CLEAN_OUTPUT feature was set from command line before the configuration files are loaded. This means the command line argument was unable to override the setting in the configuration files. I moved the code after the configuration files are loaded. The only impact is that the screen clear and printing version info for the script are performed after the configuration files are loaded. If an error occurs during that processing, those messages and sys.exit will occur before the screen is cleared and version printed. It's not a material difference in operation.